### PR TITLE
Update expression builder to exclude spaces outside of strings

### DIFF
--- a/src/expression_builder.js
+++ b/src/expression_builder.js
@@ -120,7 +120,7 @@ module.exports = function expression_builder(formula, opts) {
             fn_stack[fn_stack.length - 1].special.push(fn_stack[fn_stack.length - 1].exp);
             fn_stack[fn_stack.length - 1].exp = exp_obj = new Exp(formula);
             buffer = '';
-        } else {
+        } else if (char !== ' ') {
             buffer += char;
         }
     }

--- a/test/1-basic-test.js
+++ b/test/1-basic-test.js
@@ -887,6 +887,11 @@ describe('XLSX_CALC', function() {
         XLSX_CALC(workbook);
         assert.equal(workbook.Sheets.Sheet1.A1.v, 1979);
     });
+    it('calcs form with space after parentheses', function() {
+        workbook.Sheets.Sheet1.A1.f = '(1) * 2';
+        XLSX_CALC(workbook);
+        assert.equal(workbook.Sheets.Sheet1.A1.v, 2);
+    });
     it('calcs ref with $', function() {
         workbook.Sheets.Sheet1.A1.f = '$A$2 ';
         workbook.Sheets.Sheet1.A2.v = 1979;


### PR DESCRIPTION
This fixes issue #77 

Where spaces after a parentheses would cause undefined results.

Before fix:

| Formula  | Before Fix | After Fix |
| ------------- | ------------- | ------------- |
| 1 * 2 | 2 | 2 |
| 1 * (2)  | 2  | 2 |
| (1)* 2  | 2  | 2 |
| (1)*2  | 2  | 2 |
| (1) *2  | undefined  | 2 |
| (1) * 2  | undefined  | 2 |


