### PR TITLE
fix reference parsing when reference points to another reference

### DIFF
--- a/src/Range.js
+++ b/src/Range.js
@@ -35,12 +35,15 @@ module.exports = function Range(str_expression, formula) {
             for (var j = min_col; j <= max_col; j++) {
                 var cell_name = int_2_col_str(j) + i;
                 var cell_full_name = sheet_name + '!' + cell_name;
-                if (formula.formula_ref[cell_full_name]) {
-                    if (formula.formula_ref[cell_full_name].status === 'new') {
-                        formula.exec_formula(formula.formula_ref[cell_full_name]);
-                    }
-                    else if (formula.formula_ref[cell_full_name].status === 'working') {
-                        throw new Error('Circular ref');
+                var formula_ref = formula.formula_ref[cell_full_name];
+                if (formula_ref) {
+                    if (formula_ref.status === 'new') {
+                        formula.exec_formula(formula_ref);
+                    } else if (formula_ref.status === 'working') {
+                        if (formula_ref.cell.f.includes(formula.name)) {
+                            throw new Error('Circular ref');
+                        }
+                        formula.exec_formula(formula_ref);
                     }
                     if (sheet[cell_name].t === 'e') {
                         row.push(sheet[cell_name]);

--- a/src/RefValue.js
+++ b/src/RefValue.js
@@ -53,7 +53,11 @@ module.exports = function RefValue(str_expression, formula) {
                 return ref_cell.v;
             }
             else if (formula_ref.status === 'working') {
-                throw new Error('Circular ref');
+                if (ref_cell.f.includes(formula.name)) {
+                    throw new Error('Circular ref');
+                }
+                formula.exec_formula(formula_ref);
+                return this.calc();
             }
             else if (formula_ref.status === 'done') {
                 if (ref_cell.t === 'e') {

--- a/test/4-super-var.tests.js
+++ b/test/4-super-var.tests.js
@@ -143,4 +143,23 @@ describe('trocar variavel', () => {
         calculator.execute();
         assert.equal(workbook.Sheets.Sheet1.A1.v, 5);
     });
+
+    it('calculates cells that need to be calculated themselves', () => {
+        workbook.Sheets.Sheet1.A1.f = '1+1';
+        workbook.Sheets.Sheet1.B1.f = 'A1+1';
+
+        let calculator = XLSX_CALC.calculator(workbook);
+        calculator.execute();
+        assert.equal(workbook.Sheets.Sheet1.B1.v, 3);
+    })
+
+    it('throws a circular dependency error when multiple cells depend on each other', () => {
+        workbook.Sheets.Sheet1.A1.f = '1+B1';
+        workbook.Sheets.Sheet1.B1.f = 'A1+1';
+
+        let calculator = XLSX_CALC.calculator(workbook);
+        assert.throws(function () {
+            calculator.execute();
+        }, /Circular ref/);
+    });
 });

--- a/test/4-super-var.tests.js
+++ b/test/4-super-var.tests.js
@@ -162,4 +162,33 @@ describe('trocar variavel', () => {
             calculator.execute();
         }, /Circular ref/);
     });
+
+    it('calculates formulas in named cells', () => {
+        workbook.Workbook = {
+            Names: [{ Name: 'XPTO', Ref: 'Sheet1!A2:A3' }],
+        };
+        workbook.Sheets.Sheet1 = {
+            A1: { f: 'SUM(XPTO)' },
+            A2: { f: '2+1' },
+            A3: { f: 'A2+1' },
+        };
+        let calculator = XLSX_CALC.calculator(workbook);
+        calculator.execute();
+        assert.equal(workbook.Sheets.Sheet1.A1.v, 7);
+    });
+
+    it('throws a circular dependency error when multiple cells depend on each other in a range', () => {
+        workbook.Workbook = {
+            Names: [{ Name: 'XPTO', Ref: 'Sheet1!A2:A3' }],
+        };
+        workbook.Sheets.Sheet1 = {
+            A1: { f: 'SUM(XPTO)' },
+            A2: { f: 'A3+1' },
+            A3: { f: 'A2+1' },
+        };
+        let calculator = XLSX_CALC.calculator(workbook);
+        assert.throws(function () {
+            calculator.execute();
+        }, /Circular ref/);
+    });
 });


### PR DESCRIPTION
In cases where one reference points to another reference, for example,
when one cell has a formula definition that needs to be evaluated before
another cell can be evaluated, the RefValue would throw a circular
dependency even when it's not there.

i.e. if we have a table like this:
|   A  |   B   |
|:----:|:-----:|
| =1+1 | =A1+1 |

the reference of B1 would fail because A1 needs to be evaluated before
B1 can be evaluated. However, clearly, this case should not be identified
as a circular dependency, and instead, A1 should be evaluated first 
followed by B1.

However, if we have a table like this:
|   A  |   B   |
|:----:|:-----:|
| =B1+1 | =A1+1 |

then we have a circular dependency because to calculate A1 we need to
calculate B1 but we cannot calculate B1 without A1, etc. and in those cases
we should still see a circular dependency being thrown.

There might be edges cases where this would blow up and I'd love to discuss them :)