### PR TITLE
add memoization to range calculations

### DIFF
--- a/src/Range.js
+++ b/src/Range.js
@@ -4,8 +4,17 @@ const col_str_2_int = require('./col_str_2_int.js');
 const int_2_col_str = require('./int_2_col_str.js');
 const getSanitizedSheetName = require('./getSanitizedSheetName.js');
 
+let memo = {}, wb;
+
 module.exports = function Range(str_expression, formula) {
     this.calc = function() {
+        if (wb !== formula.wb) {
+            wb = formula.wb;
+            memo = {};
+        }
+        if (memo[str_expression]) {
+            return memo[str_expression];
+        }
         var range_expression, sheet_name, sheet;
         if (str_expression.indexOf('!') != -1) {
             var aux = str_expression.split('!');
@@ -62,6 +71,7 @@ module.exports = function Range(str_expression, formula) {
                 }
             }
         }
+        memo[str_expression] = matrix;
         return matrix;
     };
 };


### PR DESCRIPTION
Whenever ranges need to be referenced they need to be re-calculated. This can take a very long time if ranges are used often so this change aims to add a wee cache so that ranges can be calculated once.

The assumption that allows this:
* values within the range cannot change once it is calculated, i.e. no other calculation can affect a cell within a range after it was calculated as this would imply circular dependency or a mutable change

I ran this for a sheet I was playing around and this reduced the time to "calculate" it from ~6 minutes to ~2 seconds. This sheet had cells that use named variables that reference ranges, hence, without this change it would need to re-calculate all of them for every other cell.