### PR TITLE
Allow to use named ranges in formulas

### DIFF
--- a/src/Exp.js
+++ b/src/Exp.js
@@ -64,6 +64,10 @@ module.exports = function Exp(formula) {
             throw new Error('Undefined ' + obj);
         }
     }
+
+    function getCurrentCellIndex() {
+        return +self.formula.name.replace(/[^0-9]/g, '');
+    }
     
     function exec(op, args, fn) {
         for (var i = 0; i < args.length; i++) {
@@ -76,7 +80,17 @@ module.exports = function Exp(formula) {
                     } else {
                         checkVariable(args[i - 1]);
                         checkVariable(args[i + 1]);
-                        let r = fn(args[i - 1].calc(), args[i + 1].calc());
+
+                        let a = args[i - 1].calc();
+                        let b = args[i + 1].calc();
+                        if (Array.isArray(a)) {
+                            a = a[getCurrentCellIndex() - 1][0];
+                        }
+                        if (Array.isArray(b)) {
+                            b = b[getCurrentCellIndex() - 1][0];
+                        }
+
+                        let r = fn(a, b);
                         args.splice(i - 1, 3, new RawValue(r));
                         i--;
                     }

--- a/src/Range.js
+++ b/src/Range.js
@@ -35,12 +35,15 @@ module.exports = function Range(str_expression, formula) {
             for (var j = min_col; j <= max_col; j++) {
                 var cell_name = int_2_col_str(j) + i;
                 var cell_full_name = sheet_name + '!' + cell_name;
-                if (formula.formula_ref[cell_full_name]) {
-                    if (formula.formula_ref[cell_full_name].status === 'new') {
-                        formula.exec_formula(formula.formula_ref[cell_full_name]);
-                    }
-                    else if (formula.formula_ref[cell_full_name].status === 'working') {
-                        throw new Error('Circular ref');
+                var formula_ref = formula.formula_ref[cell_full_name];
+                if (formula_ref) {
+                    if (formula_ref.status === 'new') {
+                        formula.exec_formula(formula_ref);
+                    } else if (formula_ref.status === 'working') {
+                        if (formula_ref.cell.f.includes(formula.name)) {
+                            throw new Error('Circular ref');
+                        }
+                        formula.exec_formula(formula_ref);
                     }
                     if (sheet[cell_name].t === 'e') {
                         row.push(sheet[cell_name]);

--- a/src/RefValue.js
+++ b/src/RefValue.js
@@ -53,7 +53,11 @@ module.exports = function RefValue(str_expression, formula) {
                 return ref_cell.v;
             }
             else if (formula_ref.status === 'working') {
-                throw new Error('Circular ref');
+                if (ref_cell.f.includes(formula.name)) {
+                    throw new Error('Circular ref');
+                }
+                formula.exec_formula(formula_ref);
+                return this.calc();
             }
             else if (formula_ref.status === 'done') {
                 if (ref_cell.t === 'e') {

--- a/src/str_2_val.js
+++ b/src/str_2_val.js
@@ -3,6 +3,35 @@ const RefValue = require('./RefValue.js');
 const LazyValue = require('./LazyValue.js');
 const Range = require('./Range.js');
 
+// this is used to _cache_ range names so that it doesn't need to be queried
+// every time a range is used
+let definedNames, wb;
+function getDefinedName(buffer, formula) {
+    if (!(formula.wb.Workbook && formula.wb.Workbook.Names)) {
+        return null;
+    }
+    if (wb !== formula.wb) {
+        wb = formula.wb;
+        definedNames = null;
+        return getDefinedName(buffer, formula);
+    }
+    if (definedNames) {
+        return definedNames[buffer];
+    }
+    const keys = Object.values(formula.wb.Workbook.Names);
+    if (keys.length === 0) {
+        return;
+    }
+    definedNames = {};
+    keys.forEach(({ Name, Ref }) => {
+        if (!Name.includes('.')) {
+            definedNames[Name] = Ref;
+        }
+    });
+
+    return getDefinedName(buffer, formula);
+}
+
 module.exports = function str_2_val(buffer, formula) {
     if (!isNaN(buffer)) {
         return new RawValue(+buffer);
@@ -37,6 +66,9 @@ module.exports = function str_2_val(buffer, formula) {
     if (buffer.match(/%$/)) {
         var inner = str_2_val(buffer.substr(0, buffer.length-1), formula)
         return new LazyValue(() => inner.calc() / 100)
+    }
+    if (getDefinedName(buffer, formula)) {
+        return str_2_val(getDefinedName(buffer, formula), formula);
     }
     return buffer;
 };

--- a/test/4-super-var.tests.js
+++ b/test/4-super-var.tests.js
@@ -165,16 +165,18 @@ describe('trocar variavel', () => {
 
     it('calculates formulas in named cells', () => {
         workbook.Workbook = {
-            Names: [{ Name: 'XPTO', Ref: 'Sheet1!A2:A3' }],
+            Names: [{ Name: 'XPTO', Ref: 'Sheet1!A1:A2' }],
         };
         workbook.Sheets.Sheet1 = {
-            A1: { f: 'SUM(XPTO)' },
-            A2: { f: '2+1' },
-            A3: { f: 'A2+1' },
+            A1: { f: '2+1' },
+            A2: { f: 'A1+1' },   // 4
+            B2: { f: 'XPTO+1' }, // 4+1
+            A3: { f: 'SUM(XPTO)' },
         };
         let calculator = XLSX_CALC.calculator(workbook);
         calculator.execute();
-        assert.equal(workbook.Sheets.Sheet1.A1.v, 7);
+        assert.equal(workbook.Sheets.Sheet1.A3.v, 7);
+        assert.equal(workbook.Sheets.Sheet1.B2.v, 5);
     });
 
     it('throws a circular dependency error when multiple cells depend on each other in a range', () => {

--- a/test/4-super-var.tests.js
+++ b/test/4-super-var.tests.js
@@ -143,4 +143,23 @@ describe('trocar variavel', () => {
         calculator.execute();
         assert.equal(workbook.Sheets.Sheet1.A1.v, 5);
     });
+
+    it('calculates cells that need to be calculated themselves', () => {
+        workbook.Sheets.Sheet1.A1.f = '1+1';
+        workbook.Sheets.Sheet1.B1.f = 'A1+1';
+
+        let calculator = XLSX_CALC.calculator(workbook);
+        calculator.execute();
+        assert.equal(workbook.Sheets.Sheet1.B1.v, 3);
+    })
+
+    it('throws a circular dependency error when multiple cells depend on each other', () => {
+        workbook.Sheets.Sheet1.A1.f = '1+B1';
+        workbook.Sheets.Sheet1.B1.f = 'A1+1';
+
+        let calculator = XLSX_CALC.calculator(workbook);
+        assert.throws(function () {
+            calculator.execute();
+        }, /Circular ref/);
+    });
 });

--- a/test/4-super-var.tests.js
+++ b/test/4-super-var.tests.js
@@ -162,4 +162,33 @@ describe('trocar variavel', () => {
             calculator.execute();
         }, /Circular ref/);
     });
+
+    it('calculates formulas in named cells', () => {
+        workbook.Workbook = {
+            Names: [{ Name: 'XPTO', Ref: 'Sheet1!A2:A3' }],
+        };
+        workbook.Sheets.Sheet1 = {
+            A1: { f: 'SUM(XPTO)' },
+            A2: { f: '2+1' },
+            A3: { f: 'A2+1' },
+        };
+        let calculator = XLSX_CALC.calculator(workbook);
+        calculator.execute();
+        assert.equal(workbook.Sheets.Sheet1.A1.v, 7);
+    });
+
+    it('throws a circular dependency error when multiple cells depend on each other in a range', () => {
+        workbook.Workbook = {
+            Names: [{ Name: 'XPTO', Ref: 'Sheet1!A2:A3' }],
+        };
+        workbook.Sheets.Sheet1 = {
+            A1: { f: 'SUM(XPTO)' },
+            A2: { f: 'A3+1' },
+            A3: { f: 'A2+1' },
+        };
+        let calculator = XLSX_CALC.calculator(workbook);
+        assert.throws(function () {
+            calculator.execute();
+        }, /Circular ref/);
+    });
 });


### PR DESCRIPTION
At the moment formulas that reference named ranges do not work well, for example, say you have a named range called `Foo` if you wanted to have a formula that uses it, for example, `=@Foo+1` then you would see the result value as `NaN`.

This change attempts to fix it by:
* recursively calculating all values in the range (https://github.com/fabiooshiro/xlsx-calc/pull/85 would help a lot wrt performance for this operation)
* once the whole range is calculated you get a matrix of real values that you can lookup
* for formulas like `=@Foo+1` then we can figure out which cell you're currently at and pull a value from the range matrix for the same index, then run the calculation as you would normally

Note: this does expect that your cell indexes are aligned and cover the whole column, i.e. this will not work with sub-ranges.

P.S. ignore 11a5660da67b53adecd18348bcb6492cd584aae0 and a2eda354fce48391b0ea189d58ec37491dbf8b56 as they are needed for this to work but are part of https://github.com/fabiooshiro/xlsx-calc/pull/84