### PR TITLE
add option to ignore exceptions thrown executing formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ workbook.Sheets['Sheet1'].A1.v = 42;
 // recalc the workbook
 var XLSX_CALC = require('xlsx-calc');
 XLSX_CALC(workbook);
+
+// recalc options for ignoring erroneous formulas
+XLSX_CALC(workbook, { continue_after_error: true, log_error: true })
 ```
 
 ## formulajs integration

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ var mymodule = function(workbook, options) {
       try {
         exec_formula(formulas[i]);
       } catch (error) {
-        if (!options.continue_after_error) {
+        if (!options || !options.continue_after_error) {
           throw error
         }
         if (options.log_error) {

--- a/src/index.js
+++ b/src/index.js
@@ -6,14 +6,19 @@ const exec_formula = require('./exec_formula.js');
 const find_all_cells_with_formulas = require('./find_all_cells_with_formulas.js');
 const Calculator = require('./Calculator.js');
 
-var mymodule = function(workbook) {
+var mymodule = function(workbook, options) {
     var formulas = find_all_cells_with_formulas(workbook, exec_formula);
     for (var i = formulas.length - 1; i >= 0; i--) {
-        try {
-          exec_formula(formulas[i]);
-        } catch (error) {
+      try {
+        exec_formula(formulas[i]);
+      } catch (error) {
+        if (!options.continue_after_error) {
+          throw error
+        }
+        if (options.log_error) {
           console.log('error executing formula', 'sheet', formulas[i].sheet_name, 'cell', formulas[i].name, error)
         }
+      }
     }
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,11 @@ const Calculator = require('./Calculator.js');
 var mymodule = function(workbook) {
     var formulas = find_all_cells_with_formulas(workbook, exec_formula);
     for (var i = formulas.length - 1; i >= 0; i--) {
-        exec_formula(formulas[i]);
+        try {
+          exec_formula(formulas[i]);
+        } catch (error) {
+          console.log('error executing formula', 'sheet', formulas[i].sheet_name, 'cell', formulas[i].name, error)
+        }
     }
 };
 


### PR DESCRIPTION
I am modifying one worksheet of a spreadsheet and then recalculating the values.  Some of the other sheets have some erroneous formulas and the recalculation aborts as soon as an exception is thrown. 

To prevent this I have:
- wrapped formula execution in try/catch
- added options parameter to the method
- if the options parameter is not provided the exception throws per original behavior.
- if options.continue_after_error is specified the error is not thrown 
- if options.log_error is specified some information is outputted with console.log