### PR TITLE
Handle formula.js error that is returned instead of thrown

### DIFF
--- a/src/UserFnExecutor.js
+++ b/src/UserFnExecutor.js
@@ -10,6 +10,9 @@ module.exports = function UserFnExecutor(user_function) {
         var result;
         try {
             result = user_function.apply(self, self.args.map(f => f.calc()));
+            if (result instanceof Error) {
+                throw result;
+            }
         } catch (e) {
             const errorValue = getErrorValueByMessage(e.message)
             if (user_function.name === 'is_blank'

--- a/test/5-formulajs-tests.js
+++ b/test/5-formulajs-tests.js
@@ -32,4 +32,15 @@ describe('formulajs integration', function() {
             assert.strictEqual(XLSX_CALC.xlsx_Fx.TRUNC === formulajs.TRUNC, true);
         });
     });
+    describe('UserFnExecutor()', function() {
+        it('handles error that is returned instead of thrown', function() {
+            XLSX_CALC.import_functions(formulajs);
+            var workbook = {};
+            workbook.Sheets = {};
+            workbook.Sheets.Sheet1 = {};
+            workbook.Sheets.Sheet1.A2 = {f: 'AVERAGE(A1)'};
+            XLSX_CALC(workbook);
+            assert.strictEqual(workbook.Sheets.Sheet1.A2.w, '#DIV/0!');
+        });
+    })
 });


### PR DESCRIPTION
Formula.js sometimes returns errors instead of throwing them. For example, [the `AVERAGE` function returns a `#DIV/0!` error instead of throwing it](https://github.com/formulajs/formulajs/blob/d7ebccbd196148d2bf6d5a6c74aeb35d3d5538ac/src/statistical.js#L49). This causes the error object to be inserted as the value of the cell, and the `applyCellError()` function is not called.

With this fix, it will now throw the error in `UserFnExecutor()`, and then in `update_cell_value()`, so that it can be handled by `applyCellError()` eventually.