### PR TITLE
Return error object instead of state in range

### DIFF
--- a/src/Range.js
+++ b/src/Range.js
@@ -63,7 +63,7 @@ module.exports = function Range(str_expression, formula) {
                         formula.exec_formula(formula_ref);
                     }
                     if (sheet[cell_name].t === 'e') {
-                        row.push(sheet[cell_name]);
+                        row.push(new Error(sheet[cell_name].w));
                     }
                     else {
                         row.push(sheet[cell_name].v);
@@ -71,7 +71,7 @@ module.exports = function Range(str_expression, formula) {
                 }
                 else if (sheet[cell_name]) {
                     if (sheet[cell_name].t === 'e') {
-                        row.push(sheet[cell_name]);
+                        row.push(new Error(sheet[cell_name].w));
                     }
                     else {
                         row.push(sheet[cell_name].v);

--- a/src/formulas.js
+++ b/src/formulas.js
@@ -170,23 +170,23 @@ function sumproduct() {
                 if (Array.isArray(col)) {
                     for (var k = 0; k < col.length; k++) {
                         var cell = col[k];
-                        if (cell && typeof cell === 'object' && cell.t === 'e') {
-                            throw Error(cell.w);
+                        if (cell instanceof Error) {
+                            throw cell;
                         }
                     }
                 }
                 else {
                     var cell = col;
-                    if (cell && typeof cell === 'object' && cell.t === 'e') {
-                        throw Error(cell.w);
+                    if (cell instanceof Error) {
+                        throw cell;
                     }
                 }
             }
         }
         else {
             var cell = row;
-            if (cell && typeof cell === 'object' && cell.t === 'e') {
-                throw Error(cell.w);
+            if (cell instanceof Error) {
+                throw cell;
             }
         }
     }

--- a/test/1-basic-test.js
+++ b/test/1-basic-test.js
@@ -777,7 +777,7 @@ describe('XLSX_CALC', function() {
             assert.equal(workbook.Sheets.Sheet1.B3.t, 'n');
             assert.equal(workbook.Sheets.Sheet1.B3.v, 2);
         });
-        it('should preserve error state when a cell is in error', function () {
+        it('should contain error when a cell is in error', function () {
             workbook.Sheets.Sheet1.A1 = { t: "e", v: 42, w: "#N/A" };
             workbook.Sheets.Sheet1.A2 = { t: 'n', v: 1 };
             workbook.Sheets.Sheet1.A3 = { t: 'n', v: 2 };
@@ -787,7 +787,7 @@ describe('XLSX_CALC', function() {
             var formula = find_all_cells_with_formulas(workbook, exec_formula)[0];
             var range = exec_formula.build_expression(formula).args[0].calc();
             var expected = [
-                [{ t: "e", v: 42, w: "#N/A" }],
+                [new Error('#N/A')],
                 [1],
                 [2]
             ];

--- a/test/5-formulajs-tests.js
+++ b/test/5-formulajs-tests.js
@@ -42,5 +42,15 @@ describe('formulajs integration', function() {
             XLSX_CALC(workbook);
             assert.strictEqual(workbook.Sheets.Sheet1.A2.w, '#DIV/0!');
         });
+        it('handles range that contains error', function () {
+            XLSX_CALC.import_functions(formulajs);
+            var workbook = {};
+            workbook.Sheets = {};
+            workbook.Sheets.Sheet1 = {};
+            workbook.Sheets.Sheet1.A2 = {f: 'AVERAGE(A1)'};
+            workbook.Sheets.Sheet1.A3 = {f: 'INDEX(A1:A2, 2, 0)'};
+            XLSX_CALC(workbook);
+            assert.strictEqual(workbook.Sheets.Sheet1.A3.w, '#DIV/0!');
+        });
     })
 });


### PR DESCRIPTION
In #22, if a range contains error, the entire state of a cell is returned instead of an error object. This causes [error handling in formula.js](https://github.com/formulajs/formulajs/blob/0b5c0367f36a20cfb3d78ec5430d1584c58000b5/src/utils/common.js#L193) to fail because it can only handle actual error objects rather than cell states.

Instead of preserving state in case of error in a range, it should return the corresponding errors to keep everything working.

I have fixed this and added a test case for this.