### PR TITLE
IFERROR should return 0 when in reference to an empty cell

### DIFF
--- a/src/formulas-raw.js
+++ b/src/formulas-raw.js
@@ -78,7 +78,7 @@ function iferror(cell_ref, onerrorvalue) {
         if (typeof value === 'number' && (isNaN(value) || value === Infinity || value === -Infinity)) {
             return onerrorvalue.calc();
         }
-        return value;
+        return value === null ? 0 : value;
     } catch (e) {
         return onerrorvalue.calc();
     }

--- a/src/formulas-raw.js
+++ b/src/formulas-raw.js
@@ -78,7 +78,10 @@ function iferror(cell_ref, onerrorvalue) {
         if (typeof value === 'number' && (isNaN(value) || value === Infinity || value === -Infinity)) {
             return onerrorvalue.calc();
         }
-        return value === null ? 0 : value;
+        if (typeof value === 'undefined' || value === null) {
+            return 0;
+        }
+        return value;
     } catch (e) {
         return onerrorvalue.calc();
     }

--- a/test/1-basic-test.js
+++ b/test/1-basic-test.js
@@ -2147,6 +2147,12 @@ describe('XLSX_CALC', function() {
             assert.equal(workbook.Sheets.Sheet1.A2.v, 'Error');
             assert.equal(workbook.Sheets.Sheet1.A2.t, 's');
         });
+        it('returns 0 when in reference to an empty cell', function () {
+            delete workbook.Sheets.Sheet1.A1;
+            workbook.Sheets.Sheet1.A2 = { f: "IFERROR(A1, \"Error\")" };
+            XLSX_CALC(workbook);
+            assert.equal(workbook.Sheets.Sheet1.A2.v, 0);
+        })
     });
 
     describe('HLOOKUP', function () {

--- a/test/1-basic-test.js
+++ b/test/1-basic-test.js
@@ -2148,10 +2148,13 @@ describe('XLSX_CALC', function() {
             assert.equal(workbook.Sheets.Sheet1.A2.t, 's');
         });
         it('returns 0 when in reference to an empty cell', function () {
-            delete workbook.Sheets.Sheet1.A1;
+            workbook.Sheets.Sheet1.A1 = {};
             workbook.Sheets.Sheet1.A2 = { f: "IFERROR(A1, \"Error\")" };
+            delete workbook.Sheets.Sheet1.A3;
+            workbook.Sheets.Sheet1.A4 = { f: "IFERROR(A3, \"Error\")" };
             XLSX_CALC(workbook);
             assert.equal(workbook.Sheets.Sheet1.A2.v, 0);
+            assert.equal(workbook.Sheets.Sheet1.A4.v, 0);
         })
     });
 


### PR DESCRIPTION
Currently using `IFERROR` on an empty cell results in no value. But in Excel, doing so will result in 0.

This fixes the behavior of `IFERROR` to make it consistent with Excel.