### PR TITLE
Support _xlws.FILTER

### DIFF
--- a/src/formulas.js
+++ b/src/formulas.js
@@ -53,6 +53,7 @@ let formulas = {
     'SUBSTITUTE': substitute,
     'CEILING': ceiling,
     'FILTER': throwErrors(FILTER),
+    '_xlws.FILTER': throwErrors(FILTER),
     'DATEDIF': datediff,
     'EOMONTH': eomonth,
 };


### PR DESCRIPTION
The `FILTER` function from Excel can be parsed as `_xlws.FILTER` from SheetJS.

Currently the following error occurs:
```
Function _xlws.FILTER not found
```

This adds support for `FILTER` function in case it is named that way.